### PR TITLE
update idl, fix error: mediaText can only be of type DOMString or USV…

### DIFF
--- a/lib/interfaces/CSSKeyframeRule.idl
+++ b/lib/interfaces/CSSKeyframeRule.idl
@@ -1,0 +1,5 @@
+[Exposed=Window]
+interface CSSKeyframeRule : CSSRule {
+  attribute CSSOMString keyText;
+  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
+};

--- a/lib/interfaces/CSSKeyframesRule.idl
+++ b/lib/interfaces/CSSKeyframesRule.idl
@@ -1,0 +1,9 @@
+[Exposed=Window]
+interface CSSKeyframesRule : CSSRule {
+           attribute CSSOMString name;
+  readonly attribute CSSRuleList cssRules;
+
+  void             appendRule(CSSOMString rule);
+  void             deleteRule(CSSOMString select);
+  CSSKeyframeRule? findRule(CSSOMString select);
+};

--- a/lib/interfaces/MediaList.webidl
+++ b/lib/interfaces/MediaList.webidl
@@ -1,6 +1,6 @@
 [LegacyArrayClass]
 interface MediaList {
-  stringifier attribute [TreatNullAs=EmptyString] CSSOMString mediaText;
+  stringifier attribute [TreatNullAs=EmptyString] DOMString mediaText;
   readonly attribute unsigned long length;
   getter CSSOMString? item(unsigned long index);
   void appendMedium(CSSOMString medium);


### PR DESCRIPTION
…String

related discussion: https://github.com/Zirro/css-object-model/issues/10#issuecomment-398074783